### PR TITLE
Store app environment instead of relying on .aptible.env (Fixes #2)

### DIFF
--- a/src/backup.crontab.template
+++ b/src/backup.crontab.template
@@ -1,1 +1,1 @@
-CRON_SCHEDULE set -a && . /opt/app/.aptible.env && /bin/bash /opt/app/src/backup-all-indexes.sh >> /var/log/cron.log 2>&1
+CRON_SCHEDULE set -a && . /opt/app/src/app.env && /bin/bash /opt/app/src/backup-all-indexes.sh >> /var/log/cron.log 2>&1

--- a/src/run-cron.sh
+++ b/src/run-cron.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 CRON_SCHEDULE=${CRON_SCHEDULE:-"0 2 * * *"}
 sed "s:CRON_SCHEDULE:${CRON_SCHEDULE}:g" /opt/app/src/backup.crontab.template > /opt/app/src/backup.crontab
+env > /opt/app/src/app.env
 crontab /opt/app/src/backup.crontab
 touch /var/log/cron.log
 crond


### PR DESCRIPTION
Since we run `src/run-cron.sh` to generate the crontab at container startup, just dump the container env to a file in that script. Use that file later when the cron runs to recreate the environment the container started with.

This avoids strange behavior when configuration changes are made to the cron app since those changes are not propagated to `.aptible.env`
