### PR TITLE
Check all non-success states when attempting to clear a previous snapshot

### DIFF
--- a/src/backup-all-indexes.sh
+++ b/src/backup-all-indexes.sh
@@ -20,8 +20,8 @@ backup_index ()
   grep -q SUCCESS <(curl -sS ${SNAPSHOT_URL})
   if [ $? -ne 0 ]; then
     echo "Scheduling snapshot."
-    # If the snapshot previously failed, delete it so that we can try again.
-    grep -q FAILED <(curl -sS ${SNAPSHOT_URL}) && curl -sS -XDELETE ${SNAPSHOT_URL}
+    # If the snapshot exists but isn't in a success state, delete it so that we can try again.
+    grep -qE "FAILED|PARTIAL|IN_PROGRESS" <(curl -sS ${SNAPSHOT_URL}) && curl -sS -XDELETE ${SNAPSHOT_URL}
     # Indexes have to be open for snapshots to work.
     curl -sS -XPOST "${INDEX_URL}/_open"
     curl --fail -w "\n" -sS -XPUT ${SNAPSHOT_URL} -d "{


### PR DESCRIPTION
A snapshot can be in [four states](https://github.com/elastic/elasticsearch/blob/2.0/core/src/main/java/org/elasticsearch/snapshots/SnapshotState.java#L27-L42): IN_PROGRESS, SUCCESS, FAILED, or PARTIAL. To distinguish between the case when a snapshot has never been attempted and the case when a snapshot has been attempted but didn't succeed, we were checking to see if the snapshot state was FAILED (since in that case, we need to delete the bad snapshot metadata in order to retry). We recently saw a snapshot hanging around in the PARTIAL state because of an error from AWS, so this patch changes the backup code to look for any non-success state to determine whether we should clear the snapshot metadata.
