### PR TITLE
Separate bucket and bucket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Recommended setup for running as an app on Aptible:
 
      * `DATABASE_URL`: Your Elasticsearch URL.
      * `S3_BUCKET`: Your S3 Bucket name.
+     * `S3_BUCKET_BASE_PATH`: Destination path within bucket (Optional)
      * `S3_ACCESS_KEY_ID`: The access key you generated in step 3.
      * `S3_SECRET_ACCESS_KEY`: The secret key you generated in step 3.
 

--- a/src/backup-all-indexes.sh
+++ b/src/backup-all-indexes.sh
@@ -49,6 +49,7 @@ curl -w "\n" -sS -XPUT ${REPOSITORY_URL} -d "{
   \"type\": \"s3\",
   \"settings\": {
     \"bucket\" : \"${S3_BUCKET}\",
+    \"base_path\": \"${S3_BUCKET_BASE_PATH}\",
     \"access_key\": \"${S3_ACCESS_KEY_ID}\",
     \"secret_key\": \"${S3_SECRET_ACCESS_KEY}\",
     \"region\": \"${S3_REGION}\",


### PR DESCRIPTION
Providing bucket as the full path causes an XML error.
```AmazonClientException[Failed to parse XML document with handler class com.amazonaws.services.s3.model.transform.XmlResponsesSaxParser$ListBucketHandler]```

By separating the bucket and the base_path the error is no longer generated.