### PR TITLE
Region is no long longer a supported option for ES 6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ Recommended setup for running as an app on Aptible:
      * `CRON_SCHEDULE`: The schedule for your backups. Defaults to "0 2 * * *",
        which runs nightly at 2 A.M. Make sure to escape any asterisks when
        setting this variable from the command line to avoid shell expansion.
-     * `S3_REGION`: The region your Elasticsearch instance and S3 bucket live in.
-       Defaults to `us-east-1`.
      * `REPOSITORY_NAME`: The name of your Elasticsearch snapshot repo. This is
        the handle you can use in Elasticsearch to perform operations on your
        snapshot repo. Defaults to "logstash-snapshots".

--- a/src/backup-all-indexes.sh
+++ b/src/backup-all-indexes.sh
@@ -15,7 +15,6 @@ echo "$(now): backup-all-indexes.sh - Verifying required environment variables"
 DATABASE_URL="${DATABASE_URL%/}"
 
 # Set some defaults
-S3_REGION=${S3_REGION:-us-east-1}
 REPOSITORY_NAME=${REPOSITORY_NAME:-logstash_snapshots}
 WAIT_SECONDS=${WAIT_SECONDS:-1800}
 MAX_DAYS_TO_KEEP=${MAX_DAYS_TO_KEEP:-30}
@@ -82,7 +81,6 @@ curl -w "\n" -sS -XPUT ${REPOSITORY_URL} -d "{
     \"base_path\": \"${S3_BUCKET_BASE_PATH}\",
     \"access_key\": \"${S3_ACCESS_KEY_ID}\",
     \"secret_key\": \"${S3_SECRET_ACCESS_KEY}\",
-    \"region\": \"${S3_REGION}\",
     \"protocol\": \"https\",
     \"server_side_encryption\": true
   }


### PR DESCRIPTION
It doesn't seem to be required in earlier versions, either, we'll just rely on the default behavior which automatically locates the region of the configured bucket.

https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_60_plugins_changes.html