### PR TITLE
Explicitly set content-type header for PUTs with body

### DIFF
--- a/src/backup-all-indexes.sh
+++ b/src/backup-all-indexes.sh
@@ -53,7 +53,7 @@ backup_index ()
     # Indexes have to be open for snapshots to work.
     curl -sS -XPOST "${INDEX_URL}/_open"
 
-    curl --fail -w "\n" -sS -XPUT ${SNAPSHOT_URL} -d "{
+    curl -H "Content-Type: application/json" --fail -w "\n" -sS -XPUT ${SNAPSHOT_URL} -d "{
       \"indices\": \"${INDEX_NAME}\",
       \"include_global_state\": false
     }" || return 1
@@ -74,7 +74,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "$(now): Ensuring Elasticsearch snapshot repository ${REPOSITORY_NAME} exists..."
-curl -w "\n" -sS -XPUT ${REPOSITORY_URL} -d "{
+curl -H "Content-Type: application/json" -w "\n" -sS -XPUT ${REPOSITORY_URL} -d "{
   \"type\": \"s3\",
   \"settings\": {
     \"bucket\" : \"${S3_BUCKET}\",


### PR DESCRIPTION
See https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests
this is new behaviour in elasticsearch 6.0.

Fixes #19 