### PR TITLE
Add tests for default functionality.

### DIFF
--- a/src/restore-index.sh
+++ b/src/restore-index.sh
@@ -7,8 +7,11 @@ if [ -z "$1" ]; then
   exit
 fi
 
+# We need to be a able to allow self-signed certs for testing purposes
+CURL_OPTS=${CURL_OPTS:-}
+
 # Normalize DATABASE_URL by removing the trailing slash.
 DATABASE_URL="${DATABASE_URL%/}"
 
 REPOSITORY_URL=${DATABASE_URL}/_snapshot/${REPOSITORY_NAME}
-curl -w "\n" -XPOST ${REPOSITORY_URL}/$1/_restore
+curl "$CURL_OPTS" -w "\n" -XPOST ${REPOSITORY_URL}/$1/_restore

--- a/test-backup.bash
+++ b/test-backup.bash
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+DB_CONTAINER="elastic"
+DATA_CONTAINER="${DB_CONTAINER}-data"
+
+S3_BUCKET="${S3_BUCKET:-aptible-unit-tests}"
+S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}"
+S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}"
+S3_REGION="${S3_REGION:-us-east-1}"
+S3_PATH="$(date)"
+
+source ./test-functions.bash
+
+trap cleanup EXIT
+cleanup
+
+
+# Ensure s3cmd is present
+if ! which s3cmd; then
+  sudo apt-get -y install s3cmd
+fi
+
+
+docker build --tag aptible/s3-backup . > /dev/null
+# FIX THE CURL CERT ISSUE
+
+
+echo "Set up Elasticsearch"
+docker create --name "$DATA_CONTAINER" "$IMG"
+
+echo "Initializing DB"
+docker run -it --rm \
+  -e USERNAME=user -e PASSPHRASE=pass -e DATABASE=db \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" --initialize \
+  >/dev/null 2>&1
+
+echo "Starting DB"
+docker run -d --name="$DB_CONTAINER" \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG"
+
+echo "Waiting for DB to come online"
+wait_for_request "$DB_CONTAINER" "http://localhost:9200"
+echo "Ready"
+
+ES_IP="$(docker inspect --format='{{.NetworkSettings.Networks.bridge.IPAddress}}' ${DB_CONTAINER})"
+ES_URL="https://user:pass@${ES_IP}"
+
+
+
+echo "Creating test indexes"
+create_indices "$DB_CONTAINER" 40
+
+echo "Ensuring there are 40 indexes in Elasticsearch"
+[ "$(check_retention_days "$DB_CONTAINER")" == "40" ]
+
+echo "Archiving to keep only 30 days of indexes"
+# Archive the default amount of days (30)
+docker run --rm \
+  --entrypoint "/opt/app/src/backup-all-indexes.sh" \
+  -e CURL_OPTS="-k" \
+  -e DATABASE_URL="$ES_URL" \
+  -e S3_BUCKET="$S3_BUCKET" \
+  -e S3_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID" \
+  -e S3_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY" \
+  -e S3_BUCKET_BASE_PATH="$S3_PATH" \
+  --name "test-backup" \
+  "aptible/s3-backup" > /dev/null
+echo "The archive completed"
+
+echo "Checking that today and the previous 30 indexes are retained in Elasticsearch"
+[ "$(check_retention_days "$DB_CONTAINER")" == "31" ]
+
+echo "Checking that the older 9 got backed up to S3"
+[ "$(s3_count "$S3_BUCKET/$S3_PATH/indices/")" == "9" ]
+
+
+echo "Testing again, with MAX_DAYS_TO_KEEP=20"
+docker run --rm \
+  --entrypoint "/opt/app/src/backup-all-indexes.sh" \
+  -e CURL_OPTS="-k" \
+  -e DATABASE_URL="$ES_URL" \
+  -e S3_BUCKET="$S3_BUCKET" \
+  -e S3_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID" \
+  -e S3_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY" \
+  -e S3_BUCKET_BASE_PATH="$S3_PATH" \
+  -e MAX_DAYS_TO_KEEP="20" \
+  --name "test-backup" \
+  "aptible/s3-backup" > /dev/null
+
+[ "$(check_retention_days "$DB_CONTAINER")" == "21" ]
+
+[ "$(s3_count "$S3_BUCKET/$S3_PATH/indices/")" == "19" ]
+
+
+echo "Testing restoring a an index from s3"
+
+DELETED_INDEX="logstash-$(date --date="25 days ago" +"%Y.%m.%d")"
+
+[ "$(verify_index "$DELETED_INDEX")" == "missing" ]
+
+docker run -it --rm \
+  --entrypoint "/opt/app/src/restore-index.sh" \
+  -e CURL_OPTS="-k" \
+  -e DATABASE_URL="$ES_URL" \
+  -e S3_BUCKET="$S3_BUCKET" \
+  -e S3_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID" \
+  -e S3_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY" \
+  -e S3_BUCKET_BASE_PATH="$S3_PATH" \
+  --name "test-backup" \
+  "aptible/s3-backup" "$DELETED_INDEX" > /dev/null
+
+[ "$(verify_index "$DELETED_INDEX")" == "present" ]
+
+echo "All tests passed!"

--- a/test-functions.bash
+++ b/test-functions.bash
@@ -1,0 +1,61 @@
+#!/bin/bash
+function wait_for_request {
+  CONTAINER=$1
+  shift
+
+  for _ in $(seq 1 30); do
+    if docker exec -it "$CONTAINER" curl -f -v "$@" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "No response"
+  docker logs "$CONTAINER"
+  return 1
+}
+
+function create_index {
+  CONTAINER=$1
+  docker exec -it "$CONTAINER" curl -X PUT "localhost:9200/logstash-$2" -H 'Content-Type: application/json' > /dev/null
+}
+
+function create_indices {
+	CONTAINER="$1"
+  DAY=$2
+	while [ $DAY -gt 0 ]; do
+    DAY=$[$DAY-1]
+	  create_index "$CONTAINER" "$(date --date="${DAY} days ago" +"%Y.%m.%d")"
+	done
+	echo "$2 daily logstach indices created."
+}
+
+function verify_index {
+  if  docker exec -it "$CONTAINER" curl "localhost:9200/_cat/indices" | grep "$1" > /dev/null; then
+    echo "present"
+  else
+  	echo "missing"
+  fi
+}
+
+function check_retention_days {
+	CONTAINER="$1"
+	 docker exec -it "$CONTAINER" curl "localhost:9200/_cat/indices" | wc -l
+}
+
+function s3_count {
+	INDEXES="$1"
+	s3cmd --access_key="$S3_ACCESS_KEY_ID" --secret_key="$S3_SECRET_ACCESS_KEY" ls "s3://$INDEXES" | wc -l
+}
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$DB_CONTAINER" "$DATA_CONTAINER" >/dev/null 2>&1 || true
+  #docker rmi "$IMG" || true
+
+  docker rm -f test-backup > /dev/null 2>&1 || true
+  #docker rmi aptible/s3-backup || true
+
+  #s3cmd delete S3_PATH
+  s3cmd --access_key="$S3_ACCESS_KEY_ID" --secret_key="$S3_SECRET_ACCESS_KEY" rm -r "s3://$S3_BUCKET/$S3_PATH/" > /dev/null || true
+}


### PR DESCRIPTION
WORK IN PROGRESS

To test, just provide S3 keys for an Aptible account that has access to the `aptible-unit-tests` bucket, as well as the Elasticsearch image to test:

```
S3_ACCESS_KEY_ID="" \
 S3_SECRET_ACCESS_KEY="" \
 bash test-backup.bash aptible/elasticsearch:6.2
```

Alternatively, override set S3_BUCKET to provide your own bucket name for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptible/elasticsearch-logstash-s3-backup/22)
<!-- Reviewable:end -->
